### PR TITLE
COVP-133 Spring boosters - metrics for APIv1 and APIv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /venv
+ve/
 
 /api_v1/azure-functions-core-tools
 /api_v1/assets
@@ -13,6 +14,7 @@ local.settings.*
 
 local_run.sh
 
+*.pyc
 *.http
 *.yaml
 *.xml

--- a/api_v1/api_handler/constants.py
+++ b/api_v1/api_handler/constants.py
@@ -490,6 +490,12 @@ DATA_TYPES: Dict[str, Callable[[str], Any]] = {
     "cumVaccinationThirdInjectionUptakeByPublishDatePercentage": float,
     "cumPeopleVaccinatedBoosterDoseByPublishDate": int,
 
+    "cumPeopleVaccinatedAutumn22ByVaccinationDate50plus": int,
+    "cumVaccinationAutumn22UptakeByVaccinationDatePercentage50plus": float,
+    "newPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+    "cumPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+    "cumVaccinationSpring23UptakeByVaccinationDatePercentage75plus": float,
+
     "cumPCRTestsBySpecimenDate": int,
     "newPCRTestsBySpecimenDate": int,
     "newVirusTestsBySpecimenDate": int,
@@ -850,6 +856,12 @@ if ENVIRONMENT == "DEVELOPMENT":
         "newPeopleVaccinatedBoosterDoseByPublishDate": int,
         "cumVaccinationThirdInjectionUptakeByPublishDatePercentage": float,
         "cumPeopleVaccinatedBoosterDoseByPublishDate": int,
+
+        "cumPeopleVaccinatedAutumn22ByVaccinationDate50plus": int,
+        "cumVaccinationAutumn22UptakeByVaccinationDatePercentage50plus": float,
+        "newPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+        "cumPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+        "cumVaccinationSpring23UptakeByVaccinationDatePercentage75plus": float,
 
         "cumPCRTestsBySpecimenDate": int,
         "newPCRTestsBySpecimenDate": int,


### PR DESCRIPTION
Added new metrics to DATA_TYPES:
"cumPeopleVaccinatedAutumn22ByVaccinationDate50plus", "cumVaccinationAutumn22UptakeByVaccinationDatePercentage50plus", "newPeopleVaccinatedSpring23ByVaccinationDate75plus", "cumPeopleVaccinatedSpring23ByVaccinationDate75plus", "cumVaccinationSpring23UptakeByVaccinationDatePercentage75plus"